### PR TITLE
Fix use of undefined  susy deep merge

### DIFF
--- a/sass/_maps.scss
+++ b/sass/_maps.scss
@@ -101,7 +101,7 @@
     $map1: $map2;
   } @else {
     @each $key, $value in $map2 {
-      $_new: ($key: _susy_deep-merge(map-get($map1, $key), $value));
+      $_new: ($key: deep-merge(map-get($map1, $key), $value));
       $map1: map-merge($map1, $_new);
     }
   }

--- a/test/scss/test.scss
+++ b/test/scss/test.scss
@@ -99,4 +99,58 @@ $map: (
 }
 
 
+// deep-merge
+// ----------
+@include test-module('deep-merge [function]') {
+  @include test('Merge two nested maps') {
+    $new-map: (
+      one: (
+        hello: (
+          cocktail: pop,
+        ),
+        
+      )
+    );
+    $test: deep-merge($map, $new-map);
+    $expect: (
+      one: (
+        hello: (
+          world: new york,
+          pizza: sausage,
+          cocktail: pop,
+        ),
+        goodbye: fugard,
+      ),
+      two: cheese,
+    );
+    @include assert-equal($test, $expect,
+      'Merges nested maps.');
+  }
+
+  @include test('Merge two nested maps with matching keys') {
+    $new-map: (
+      one: (
+        hello: (
+          world: jenin,
+        ),
+        
+      )
+    );
+    $test: deep-merge($map, $new-map);
+    $expect: (
+      one: (
+        hello: (
+          world: jenin,
+          pizza: sausage,
+        ),
+        goodbye: fugard,
+      ),
+      two: cheese,
+    );
+    @include assert-equal($test, $expect,
+      'Merges nested maps with matching keys.');
+  }
+}
+
+
 @include report;


### PR DESCRIPTION
This pull request fixes the use of an undefined function in place of recursion inside the `deep-merge` function, and adds tests for `deep-merge`
